### PR TITLE
readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,8 +34,8 @@ Write a program that
   answers to questions about the language (as opposed to questions about this
   problem).
 
-- Please document and format your code well and consistently, wrap lines at 79
-  or 80 characters whenever possible, and end your file with a blank line; the
+- Please document and format your code well and consistently, wrap lines at column 79
+  or 80 whenever possible, and end your file with a blank line; the
   solution to this problem should only need one file.
 
 ### Sample Run


### PR DESCRIPTION
fixed characters to column since tab registers as one character and will throw off character count in one chooses spaces over indents.
